### PR TITLE
feat: add visionOS demo project

### DIFF
--- a/Demo/Demo-visionOS/Demo-visionOS.xcodeproj/project.pbxproj
+++ b/Demo/Demo-visionOS/Demo-visionOS.xcodeproj/project.pbxproj
@@ -1,0 +1,398 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A10000012D000000000000001 /* Demo_visionOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000E2D000000000000001 /* Demo_visionOSApp.swift */; };
+		A10000012D000000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000E2D000000000000002 /* ContentView.swift */; };
+		A10000012D000000000000003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A100000E2D000000000000003 /* Assets.xcassets */; };
+		A10000012D000000000000004 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A100000E2D000000000000004 /* Preview Assets.xcassets */; };
+		A10000012D000000000000005 /* MPVPlayerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000E2D000000000000005 /* MPVPlayerDelegate.swift */; };
+		A10000012D000000000000006 /* MPVProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000E2D000000000000006 /* MPVProperty.swift */; };
+		A10000012D000000000000007 /* MetalLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000E2D000000000000007 /* MetalLayer.swift */; };
+		A10000012D000000000000008 /* MPVMetalPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000E2D000000000000008 /* MPVMetalPlayerView.swift */; };
+		A10000012D000000000000009 /* MPVMetalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000E2D000000000000009 /* MPVMetalViewController.swift */; };
+		A100000F2D000000000000001 /* MPVKit-GPL in Frameworks */ = {isa = PBXBuildFile; productRef = A100000D2D000000000000001 /* MPVKit-GPL */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		A100000A2D000000000000001 /* Demo-visionOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Demo-visionOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A100000E2D000000000000001 /* Demo_visionOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Demo_visionOSApp.swift; sourceTree = "<group>"; };
+		A100000E2D000000000000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		A100000E2D000000000000003 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A100000E2D000000000000004 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		A100000E2D000000000000005 /* MPVPlayerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPVPlayerDelegate.swift; sourceTree = "<group>"; };
+		A100000E2D000000000000006 /* MPVProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPVProperty.swift; sourceTree = "<group>"; };
+		A100000E2D000000000000007 /* MetalLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalLayer.swift; sourceTree = "<group>"; };
+		A100000E2D000000000000008 /* MPVMetalPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPVMetalPlayerView.swift; sourceTree = "<group>"; };
+		A100000E2D000000000000009 /* MPVMetalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPVMetalViewController.swift; sourceTree = "<group>"; };
+		A100000E2D00000000000000A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		A100000E2D00000000000000B /* MPVKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = MPVKit; path = ../..; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A100000B2D000000000000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A100000F2D000000000000001 /* MPVKit-GPL in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A100000022D000000000000001 = {
+			isa = PBXGroup;
+			children = (
+				A100000022D000000000000002 /* Demo-visionOS */,
+				A100000022D000000000000003 /* Products */,
+				A100000022D000000000000004 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		A100000022D000000000000002 /* Demo-visionOS */ = {
+			isa = PBXGroup;
+			children = (
+				A100000E2D00000000000000A /* Info.plist */,
+				A100000022D000000000000005 /* Player */,
+				A100000E2D000000000000001 /* Demo_visionOSApp.swift */,
+				A100000E2D000000000000002 /* ContentView.swift */,
+				A100000E2D000000000000003 /* Assets.xcassets */,
+				A100000022D000000000000008 /* Preview Content */,
+			);
+			path = "Demo-visionOS";
+			sourceTree = "<group>";
+		};
+		A100000022D000000000000003 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A100000A2D000000000000001 /* Demo-visionOS.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A100000022D000000000000004 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				A100000E2D00000000000000B /* MPVKit */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		A100000022D000000000000005 /* Player */ = {
+			isa = PBXGroup;
+			children = (
+				A100000E2D000000000000005 /* MPVPlayerDelegate.swift */,
+				A100000E2D000000000000006 /* MPVProperty.swift */,
+				A100000022D000000000000006 /* Metal */,
+			);
+			path = Player;
+			sourceTree = "<group>";
+		};
+		A100000022D000000000000006 /* Metal */ = {
+			isa = PBXGroup;
+			children = (
+				A100000E2D000000000000007 /* MetalLayer.swift */,
+				A100000E2D000000000000008 /* MPVMetalPlayerView.swift */,
+				A100000E2D000000000000009 /* MPVMetalViewController.swift */,
+			);
+			path = Metal;
+			sourceTree = "<group>";
+		};
+		A100000022D000000000000008 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				A100000E2D000000000000004 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A100000C2D000000000000001 /* Demo-visionOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A100000082D000000000000002 /* Build configuration list for PBXNativeTarget "Demo-visionOS" */;
+			buildPhases = (
+				A100000B2D000000000000002 /* Sources */,
+				A100000B2D000000000000001 /* Frameworks */,
+				A100000B2D000000000000003 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Demo-visionOS";
+			packageProductDependencies = (
+				A100000D2D000000000000001 /* MPVKit-GPL */,
+			);
+			productName = "Demo-visionOS";
+			productReference = A100000A2D000000000000001 /* Demo-visionOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A100000092D000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1540;
+				LastUpgradeCheck = 1540;
+				TargetAttributes = {
+					A100000C2D000000000000001 = {
+						CreatedOnToolsVersion = 15.4;
+					};
+				};
+			};
+			buildConfigurationList = A100000082D000000000000001 /* Build configuration list for PBXProject "Demo-visionOS" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A100000022D000000000000001;
+			packageReferences = (
+			);
+			productRefGroup = A100000022D000000000000003 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A100000C2D000000000000001 /* Demo-visionOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A100000B2D000000000000003 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000012D000000000000004 /* Preview Assets.xcassets in Resources */,
+				A10000012D000000000000003 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A100000B2D000000000000002 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000012D000000000000009 /* MPVMetalViewController.swift in Sources */,
+				A10000012D000000000000002 /* ContentView.swift in Sources */,
+				A10000012D000000000000007 /* MetalLayer.swift in Sources */,
+				A10000012D000000000000001 /* Demo_visionOSApp.swift in Sources */,
+				A10000012D000000000000006 /* MPVProperty.swift in Sources */,
+				A10000012D000000000000005 /* MPVPlayerDelegate.swift in Sources */,
+				A10000012D000000000000008 /* MPVMetalPlayerView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A100000072D000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = xros;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				XROS_DEPLOYMENT_TARGET = 1.0;
+			};
+			name = Debug;
+		};
+		A100000072D000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = xros;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				XROS_DEPLOYMENT_TARGET = 1.0;
+			};
+			name = Release;
+		};
+		A100000072D000000000000003 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Demo-visionOS/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Demo-visionOS/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mpvkit.Demo-visionOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 7;
+			};
+			name = Debug;
+		};
+		A100000072D000000000000004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Demo-visionOS/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Demo-visionOS/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mpvkit.Demo-visionOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 7;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A100000082D000000000000001 /* Build configuration list for PBXProject "Demo-visionOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A100000072D000000000000001 /* Debug */,
+				A100000072D000000000000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A100000082D000000000000002 /* Build configuration list for PBXNativeTarget "Demo-visionOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A100000072D000000000000003 /* Debug */,
+				A100000072D000000000000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A100000D2D000000000000001 /* MPVKit-GPL */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "MPVKit-GPL";
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = A100000092D000000000000001 /* Project object */;
+}

--- a/Demo/Demo-visionOS/Demo-visionOS.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Demo/Demo-visionOS/Demo-visionOS.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AppIcon.solidimagestack/Back.solidimagestacklayer/Content.imageset/Contents.json
+++ b/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AppIcon.solidimagestack/Back.solidimagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "vision",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AppIcon.solidimagestack/Back.solidimagestacklayer/Contents.json
+++ b/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AppIcon.solidimagestack/Back.solidimagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AppIcon.solidimagestack/Contents.json
+++ b/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AppIcon.solidimagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "layers" : [
+    {
+      "filename" : "Front.solidimagestacklayer"
+    },
+    {
+      "filename" : "Middle.solidimagestacklayer"
+    },
+    {
+      "filename" : "Back.solidimagestacklayer"
+    }
+  ]
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AppIcon.solidimagestack/Front.solidimagestacklayer/Content.imageset/Contents.json
+++ b/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AppIcon.solidimagestack/Front.solidimagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "vision",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AppIcon.solidimagestack/Front.solidimagestacklayer/Contents.json
+++ b/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AppIcon.solidimagestack/Front.solidimagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AppIcon.solidimagestack/Middle.solidimagestacklayer/Content.imageset/Contents.json
+++ b/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AppIcon.solidimagestack/Middle.solidimagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "vision",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AppIcon.solidimagestack/Middle.solidimagestacklayer/Contents.json
+++ b/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/AppIcon.solidimagestack/Middle.solidimagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/Contents.json
+++ b/Demo/Demo-visionOS/Demo-visionOS/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/ContentView.swift
+++ b/Demo/Demo-visionOS/Demo-visionOS/ContentView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct ContentView: View {
+    @ObservedObject var coordinator = MPVMetalPlayerView.Coordinator()
+    @State var loading = false
+
+
+    var body: some View {
+        VStack {
+            MPVMetalPlayerView(coordinator: coordinator)
+                .play(URL(string: "https://github.com/mpvkit/video-test/raw/master/resources/HDR10_ToneMapping_Test_240_1000_nits.mp4")!)
+                .onPropertyChange{ player, propertyName, propertyData in
+                    switch propertyName {
+                    case MPVProperty.pausedForCache:
+                        loading = propertyData as! Bool
+                    default: break
+                    }
+                }
+        }
+        .overlay {
+            VStack {
+                Spacer()
+                ScrollView(.horizontal) {
+                    HStack {
+                        Button {
+                            coordinator.play(URL(string: "https://vjs.zencdn.net/v/oceans.mp4")!)
+                        } label: {
+                            Text("h264").frame(width: 130, height: 100)
+                        }
+                        Button {
+                            coordinator.play(URL(string: "https://github.com/mpvkit/video-test/raw/master/resources/h265.mp4")!)
+                        } label: {
+                            Text("h265").frame(width: 130, height: 100)
+                        }
+                        Button {
+                            coordinator.play(URL(string: "https://github.com/mpvkit/video-test/raw/master/resources/pgs_subtitle.mkv")!)
+                        } label: {
+                            Text("subtitle").frame(width: 130, height: 100)
+                        }
+                        Button {
+                            coordinator.play(URL(string: "https://github.com/mpvkit/video-test/raw/master/resources/hdr.mkv")!)
+                        } label: {
+                            Text("HDR").frame(width: 130, height: 100)
+                        }
+                        Button {
+                            coordinator.play(URL(string: "https://github.com/mpvkit/video-test/raw/master/resources/DolbyVision_P5.mp4")!)
+                        } label: {
+                            Text("DV_P5").frame(width: 130, height: 100)
+                        }
+                        Button {
+                            coordinator.play(URL(string: "https://github.com/mpvkit/video-test/raw/master/resources/DolbyVision_P8.mp4")!)
+                        } label: {
+                            Text("DV_P8").frame(width: 130, height: 100)
+                        }
+                    }
+                }
+            }
+        }
+        .overlay(overlayView)
+        .preferredColorScheme(.dark)
+    }
+
+    @ViewBuilder
+    private var overlayView: some View {
+        if loading {
+            ProgressView()
+        } else {
+            EmptyView()
+        }
+    }
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Demo_visionOSApp.swift
+++ b/Demo/Demo-visionOS/Demo-visionOS/Demo_visionOSApp.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+@main
+struct Demo_visionOSApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .defaultSize(width: 1280, height: 720)
+    }
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Info.plist
+++ b/Demo/Demo-visionOS/Demo-visionOS/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/Demo/Demo-visionOS/Demo-visionOS/Player/MPVPlayerDelegate.swift
+++ b/Demo/Demo-visionOS/Demo-visionOS/Player/MPVPlayerDelegate.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+@MainActor
+public protocol MPVPlayerDelegate: AnyObject {
+    func propertyChange(mpv: OpaquePointer, propertyName: String, data: Any?)
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Player/MPVProperty.swift
+++ b/Demo/Demo-visionOS/Demo-visionOS/Player/MPVProperty.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct MPVProperty {
+    static let videoParamsColormatrix = "video-params/colormatrix"
+    static let videoParamsColorlevels = "video-params/colorlevels"
+    static let videoParamsPrimaries = "video-params/primaries"
+    static let videoParamsGamma = "video-params/gamma"
+    static let videoParamsSigPeak = "video-params/sig-peak"
+    static let videoParamsSceneMaxR = "video-params/scene-max-r"
+    static let videoParamsSceneMaxG = "video-params/scene-max-g"
+    static let videoParamsSceneMaxB = "video-params/scene-max-b"
+    static let pause = "pause"
+    static let pausedForCache = "paused-for-cache"
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Player/Metal/MPVMetalPlayerView.swift
+++ b/Demo/Demo-visionOS/Demo-visionOS/Player/Metal/MPVMetalPlayerView.swift
@@ -1,0 +1,50 @@
+import Foundation
+import SwiftUI
+
+struct MPVMetalPlayerView: UIViewControllerRepresentable {
+    @ObservedObject var coordinator: Coordinator
+
+    func makeUIViewController(context: Context) -> some UIViewController {
+        let mpv =  MPVMetalViewController()
+        mpv.playDelegate = coordinator
+        mpv.playUrl = coordinator.playUrl
+
+        context.coordinator.player = mpv
+        return mpv
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
+    }
+
+    public func makeCoordinator() -> Coordinator {
+        coordinator
+    }
+
+    func play(_ url: URL) -> Self {
+        coordinator.playUrl = url
+        return self
+    }
+
+    func onPropertyChange(_ handler: @escaping (MPVMetalViewController, String, Any?) -> Void) -> Self {
+        coordinator.onPropertyChange = handler
+        return self
+    }
+
+    @MainActor
+    public final class Coordinator: MPVPlayerDelegate, ObservableObject {
+        weak var player: MPVMetalViewController?
+
+        var playUrl : URL?
+        var onPropertyChange: ((MPVMetalViewController, String, Any?) -> Void)?
+
+        func play(_ url: URL) {
+            player?.loadFile(url)
+        }
+
+        func propertyChange(mpv: OpaquePointer, propertyName: String, data: Any?) {
+            guard let player else { return }
+
+            self.onPropertyChange?(player, propertyName, data)
+        }
+    }
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Player/Metal/MPVMetalViewController.swift
+++ b/Demo/Demo-visionOS/Demo-visionOS/Player/Metal/MPVMetalViewController.swift
@@ -1,0 +1,217 @@
+import Foundation
+import UIKit
+import Libmpv
+
+// warning: metal API validation has been disabled to ignore crash when playing HDR videos.
+// Edit Scheme -> Run -> Diagnostics -> Metal API Validation -> Turn it off
+// https://github.com/KhronosGroup/MoltenVK/issues/2226
+final class MPVMetalViewController: UIViewController {
+    var metalLayer = MetalLayer()
+    var mpv: OpaquePointer!
+    var playDelegate: MPVPlayerDelegate?
+    lazy var queue = DispatchQueue(label: "mpv", qos: .userInitiated)
+
+    var playUrl: URL?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        metalLayer.frame = view.frame
+        metalLayer.contentsScale = UITraitCollection.current.displayScale
+        metalLayer.framebufferOnly = true
+        metalLayer.backgroundColor = UIColor.black.cgColor
+
+        view.layer.addSublayer(metalLayer)
+
+        setupMpv()
+
+        if let url = playUrl {
+            loadFile(url)
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        metalLayer.frame = view.frame
+    }
+
+    func setupMpv() {
+        mpv = mpv_create()
+        if mpv == nil {
+            print("failed creating context\n")
+            exit(1)
+        }
+
+        // https://mpv.io/manual/stable/#options
+#if DEBUG
+        checkError(mpv_request_log_messages(mpv, "debug"))
+#else
+        checkError(mpv_request_log_messages(mpv, "no"))
+#endif
+        checkError(mpv_set_option(mpv, "wid", MPV_FORMAT_INT64, &metalLayer))
+        checkError(mpv_set_option_string(mpv, "subs-match-os-language", "yes"))
+        checkError(mpv_set_option_string(mpv, "subs-fallback", "yes"))
+        checkError(mpv_set_option_string(mpv, "vo", "gpu-next"))
+        checkError(mpv_set_option_string(mpv, "gpu-api", "vulkan"))
+        checkError(mpv_set_option_string(mpv, "gpu-context", "moltenvk"))
+        checkError(mpv_set_option_string(mpv, "hwdec", "videotoolbox"))
+        checkError(mpv_set_option_string(mpv, "video-rotate", "no"))
+
+        checkError(mpv_initialize(mpv))
+
+        mpv_observe_property(mpv, 0, MPVProperty.videoParamsSigPeak, MPV_FORMAT_DOUBLE)
+        mpv_observe_property(mpv, 0, MPVProperty.pausedForCache, MPV_FORMAT_FLAG)
+        mpv_set_wakeup_callback(self.mpv, { (ctx) in
+            let client = unsafeBitCast(ctx, to: MPVMetalViewController.self)
+            client.readEvents()
+        }, UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque()))
+    }
+
+
+    func loadFile(
+        _ url: URL
+    ) {
+        var args = [url.absoluteString]
+        var options = [String]()
+
+        args.append("replace")
+
+        if !options.isEmpty {
+            args.append(options.joined(separator: ","))
+        }
+
+        command("loadfile", args: args)
+    }
+
+    func togglePause() {
+        getFlag(MPVProperty.pause) ? play() : pause()
+    }
+
+    func play() {
+        setFlag(MPVProperty.pause, false)
+    }
+
+    func pause() {
+        setFlag(MPVProperty.pause, true)
+    }
+
+    private func getDouble(_ name: String) -> Double {
+        guard mpv != nil else { return 0.0 }
+        var data = Double()
+        mpv_get_property(mpv, name, MPV_FORMAT_DOUBLE, &data)
+        return data
+    }
+
+    private func getString(_ name: String) -> String? {
+        guard mpv != nil else { return nil }
+        let cstr = mpv_get_property_string(mpv, name)
+        let str: String? = cstr == nil ? nil : String(cString: cstr!)
+        mpv_free(cstr)
+        return str
+    }
+
+    private func getFlag(_ name: String) -> Bool {
+        var data = Int64()
+        mpv_get_property(mpv, name, MPV_FORMAT_FLAG, &data)
+        return data > 0
+    }
+
+    private func setFlag(_ name: String, _ flag: Bool) {
+        guard mpv != nil else { return }
+        var data: Int = flag ? 1 : 0
+        mpv_set_property(mpv, name, MPV_FORMAT_FLAG, &data)
+    }
+
+
+    func command(
+        _ command: String,
+        args: [String?] = [],
+        checkForErrors: Bool = true,
+        returnValueCallback: ((Int32) -> Void)? = nil
+    ) {
+        guard mpv != nil else {
+            return
+        }
+        var cargs = makeCArgs(command, args).map { $0.flatMap { UnsafePointer<CChar>(strdup($0)) } }
+        defer {
+            for ptr in cargs where ptr != nil {
+                free(UnsafeMutablePointer(mutating: ptr!))
+            }
+        }
+        let returnValue = mpv_command(mpv, &cargs)
+        if checkForErrors {
+            checkError(returnValue)
+        }
+        if let cb = returnValueCallback {
+            cb(returnValue)
+        }
+    }
+
+    private func makeCArgs(_ command: String, _ args: [String?]) -> [String?] {
+        if !args.isEmpty, args.last == nil {
+            fatalError("Command do not need a nil suffix")
+        }
+
+        var strArgs = args
+        strArgs.insert(command, at: 0)
+        strArgs.append(nil)
+
+        return strArgs
+    }
+
+    func readEvents() {
+        queue.async { [weak self] in
+            guard let self else { return }
+
+            while self.mpv != nil {
+                let event = mpv_wait_event(self.mpv, 0)
+                if event?.pointee.event_id == MPV_EVENT_NONE {
+                    break
+                }
+
+                switch event!.pointee.event_id {
+                case MPV_EVENT_PROPERTY_CHANGE:
+                    let dataOpaquePtr = OpaquePointer(event!.pointee.data)
+                    if let property = UnsafePointer<mpv_event_property>(dataOpaquePtr)?.pointee {
+                        let propertyName = String(cString: property.name)
+                        switch propertyName {
+                        case MPVProperty.videoParamsSigPeak:
+                            if let sigPeak = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee {
+                                DispatchQueue.main.async {
+                                    self.playDelegate?.propertyChange(mpv: self.mpv, propertyName: propertyName, data: sigPeak)
+                                }
+                            }
+                        case MPVProperty.pausedForCache:
+                            let buffering = UnsafePointer<Bool>(OpaquePointer(property.data))?.pointee ?? true
+                            DispatchQueue.main.async {
+                                self.playDelegate?.propertyChange(mpv: self.mpv, propertyName: propertyName, data: buffering)
+                            }
+                        default: break
+                        }
+                    }
+                case MPV_EVENT_SHUTDOWN:
+                    print("event: shutdown\n");
+                    mpv_terminate_destroy(mpv);
+                    mpv = nil;
+                    break;
+                case MPV_EVENT_LOG_MESSAGE:
+                    let msg = UnsafeMutablePointer<mpv_event_log_message>(OpaquePointer(event!.pointee.data))
+                    print("[\(String(cString: (msg!.pointee.prefix)!))] \(String(cString: (msg!.pointee.level)!)): \(String(cString: (msg!.pointee.text)!))", terminator: "")
+                default:
+                    let eventName = mpv_event_name(event!.pointee.event_id )
+                    print("event: \(String(cString: (eventName)!))");
+                }
+
+            }
+        }
+    }
+
+
+    private func checkError(_ status: CInt) {
+        if status < 0 {
+            print("MPV API error: \(String(cString: mpv_error_string(status)))\n")
+        }
+    }
+
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Player/Metal/MetalLayer.swift
+++ b/Demo/Demo-visionOS/Demo-visionOS/Player/Metal/MetalLayer.swift
@@ -1,0 +1,34 @@
+import Foundation
+import UIKit
+
+class MetalLayer: CAMetalLayer {
+
+    // workaround for a MoltenVK that sets the drawableSize to 1x1 to forcefully complete
+    // the presentation, this causes flicker and the drawableSize possibly staying at 1x1
+    // https://github.com/mpv-player/mpv/pull/13651
+    override var drawableSize: CGSize {
+        get { return super.drawableSize }
+        set {
+            if Int(newValue.width) > 1 && Int(newValue.height) > 1 {
+                super.drawableSize = newValue
+            }
+        }
+    }
+
+    // Hack for fix [target-colorspace-hint] option:
+    // Update wantsExtendedDynamicRangeContent need run in main thread to activate screen EDR mode, other thread can't activate
+    override var wantsExtendedDynamicRangeContent: Bool  {
+        get {
+            return super.wantsExtendedDynamicRangeContent
+        }
+        set {
+            if Thread.isMainThread {
+                super.wantsExtendedDynamicRangeContent = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    super.wantsExtendedDynamicRangeContent = newValue
+                }
+            }
+        }
+    }
+}

--- a/Demo/Demo-visionOS/Demo-visionOS/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Demo/Demo-visionOS/Demo-visionOS/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demo/Demo.xcworkspace/contents.xcworkspacedata
+++ b/Demo/Demo.xcworkspace/contents.xcworkspacedata
@@ -10,4 +10,7 @@
    <FileRef
       location = "group:Demo-macOS/Demo-macOS.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Demo-visionOS/Demo-visionOS.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 
 import PackageDescription
 
 let package = Package(
     name: "MPVKit",
-    platforms: [.macOS(.v11), .iOS(.v14), .tvOS(.v14)],
+    platforms: [.macOS(.v11), .iOS(.v14), .tvOS(.v14), .visionOS(.v1)],
     products: [
         .library(
             name: "MPVKit",

--- a/docs/Package.template.swift
+++ b/docs/Package.template.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 
 import PackageDescription
 
 let package = Package(
     name: "MPVKit",
-    platforms: [.macOS(.v11), .iOS(.v14), .tvOS(.v14)],
+    platforms: [.macOS(.v11), .iOS(.v14), .tvOS(.v14), .visionOS(.v1)],
     products: [
         .library(
             name: "MPVKit",


### PR DESCRIPTION
## Summary
- Add a new **Demo-visionOS** project to the demo workspace, matching the patterns used by the existing iOS, macOS, and tvOS demos
- Metal-only rendering (no OpenGL on visionOS)
- Adapted for visionOS platform differences: no `UIScreen.main`, no background/foreground lifecycle hacks, visionOS-appropriate window sizing

Closes #6

## Notes
- Built and verified against the current `MPVKit-GPL` package (libmpv 0.41.0, FFmpeg n8.1)
- The original issue (#6) reported a `SIGABRT` from libplacebo/MoltenVK (`ios-metal0.0` shader compilation error + `pl_lcm` assertion) on older versions — this has been resolved in newer MPVKit releases
- The demo compiles successfully for visionOS device (`xros` SDK)

## Test plan
- [x] Build succeeds for visionOS device target (`CODE_SIGNING_ALLOWED=NO`)
- [x] Verify video playback on visionOS Simulator or device
- [x] Test all codec buttons (h264, h265, subtitle, HDR, DV_P5, DV_P8)