### PR TITLE
Enable avfoundation audio output on iOS/tvOS

### DIFF
--- a/Sources/BuildScripts/XCFrameworkBuild/main.swift
+++ b/Sources/BuildScripts/XCFrameworkBuild/main.swift
@@ -425,11 +425,13 @@ private class BuildMPV: BaseBuild {
             array.append("-Dvideotoolbox-pl=enabled")
             array.append("-Dswift-build=disabled")
             array.append("-Daudiounit=enabled")
-            array.append("-Davfoundation=disabled")
+            // Enable the avfoundation AO (AVSampleBufferAudioRenderer) on iOS/tvOS.
+            // CoreAudio HAL (AudioObject*) is macOS-only, so keep coreaudio off.
+            array.append("-Davfoundation=enabled")
+            array.append("-Dcoreaudio=disabled")
             array.append("-Dlua=disabled")
             if platform == .maccatalyst {
                 array.append("-Dcocoa=disabled")
-                array.append("-Dcoreaudio=disabled")
             } else if platform == .xros || platform == .xrsimulator {
                 array.append("-Dios-gl=disabled")
             } else {

--- a/Sources/BuildScripts/patch/libmpv/0003-enable-avfoundation-ao-tvos.patch
+++ b/Sources/BuildScripts/patch/libmpv/0003-enable-avfoundation-ao-tvos.patch
@@ -1,0 +1,176 @@
+diff --git a/audio/out/ao_avfoundation.m b/audio/out/ao_avfoundation.m
+index 09f3ef0..c13f601 100644
+--- a/audio/out/ao_avfoundation.m
++++ b/audio/out/ao_avfoundation.m
+@@ -206,10 +206,10 @@ - (instancetype)initWithAO:(struct ao*)_ao {
+     return self;
+ }
+ - (void)handleRestartNotification:(NSNotification*)notification {
+-    char *name = cfstr_get_cstr((CFStringRef)notification.name);
++    // Use NSString -UTF8String (portable) instead of cfstr_get_cstr, whose
++    // implementation (osdep/utils-mac.c) is only built on macOS (Cocoa).
+     MP_WARN(ao, "restarting due to system notification; this will cause desync\n");
+-    MP_VERBOSE(ao, "notification name: %s\n", name);
+-    talloc_free(name);
++    MP_VERBOSE(ao, "notification name: %s\n", notification.name.UTF8String);
+     stop(ao);
+     start(ao);
+ }
+@@ -249,9 +249,12 @@ static int init(struct ao *ao)
+         goto error;
+     }
+ 
++#if !TARGET_OS_IPHONE
++    // Output-device selection is macOS-only; iOS/tvOS have a single fixed output.
+     if (ao->device && ao->device[0]) {
+         [p->renderer setAudioOutputDeviceUniqueID:(NSString*)cfstr_from_cstr(ao->device)];
+     }
++#endif
+ 
+     [p->synchronizer addRenderer:p->renderer];
+ #if HAVE_MACOS_11_3_FEATURES
+@@ -362,6 +365,8 @@ static void uninit(struct ao *ao)
+     .reset          = stop,
+     .start          = start,
+     .set_pause      = set_pause,
++#if !TARGET_OS_IPHONE
+     .list_devs      = ca_get_device_list,
++#endif
+     .priv_size      = sizeof(struct priv),
+ };
+diff --git a/audio/out/ao_coreaudio_chmap.c b/audio/out/ao_coreaudio_chmap.c
+index 2c6131f..b926d6b 100644
+--- a/audio/out/ao_coreaudio_chmap.c
++++ b/audio/out/ao_coreaudio_chmap.c
+@@ -405,6 +405,10 @@ coreaudio_error:
+     return false;
+ }
+ 
++#if !TARGET_OS_IPHONE
++// Device-querying helpers below use the CoreAudio HAL (AudioObject*/
++// AudioDeviceID), which is macOS-only. iOS/tvOS have a single fixed output and
++// no device selection, so these are not needed (and not even available there).
+ static AudioChannelLayout* ca_query_layout(struct ao *ao,
+                                            AudioDeviceID device,
+                                            void *talloc_ctx)
+@@ -532,4 +536,5 @@ void ca_get_active_chmap(struct ao *ao, AudioDeviceID device, int channel_count,
+     MP_WARN(ao, "mismatching channels - falling back to %s\n",
+             mp_chmap_to_str(out_map));
+ }
++#endif // device HAL (!TARGET_OS_IPHONE)
+ #endif
+diff --git a/audio/out/ao_coreaudio_chmap.h b/audio/out/ao_coreaudio_chmap.h
+index d8bdc59..fe42095 100644
+--- a/audio/out/ao_coreaudio_chmap.h
++++ b/audio/out/ao_coreaudio_chmap.h
+@@ -19,6 +19,7 @@
+ #define MPV_COREAUDIO_CHMAP_H
+ 
+ #include "config.h"
++#include <TargetConditionals.h>
+ #include <AudioToolbox/AudioToolbox.h>
+ 
+ struct mp_chmap;
+@@ -30,9 +31,11 @@ AudioChannelLabel mp_speaker_id_to_ca_label(int speaker_id);
+ AudioChannelLayout *ca_find_standard_layout(void *talloc_ctx, AudioChannelLayout *l);
+ AudioChannelLayout *ca_get_acl(struct ao *ao, size_t *out_layout_size);
+ void ca_log_layout(struct ao *ao, int l, AudioChannelLayout *layout);
++#if !TARGET_OS_IPHONE
+ bool ca_init_chmap(struct ao *ao, AudioDeviceID device);
+ void ca_get_active_chmap(struct ao *ao, AudioDeviceID device, int channel_count,
+                          struct mp_chmap *out_map);
+ #endif
++#endif
+ 
+ #endif
+diff --git a/audio/out/ao_coreaudio_properties.c b/audio/out/ao_coreaudio_properties.c
+index 1786602..5d92b58 100644
+--- a/audio/out/ao_coreaudio_properties.c
++++ b/audio/out/ao_coreaudio_properties.c
+@@ -19,6 +19,11 @@
+  * Abstractions on the CoreAudio API to make property setting/getting suck less
+ */
+ 
++#include <TargetConditionals.h>
++// The whole file is CoreAudio HAL (AudioObject* property access), macOS-only.
++// iOS/tvOS have no device-property API; the avfoundation AO there doesn't use it.
++#if !TARGET_OS_IPHONE
++
+ #include "audio/out/ao_coreaudio_properties.h"
+ #include "audio/out/ao_coreaudio_utils.h"
+ #include "mpv_talloc.h"
+@@ -101,3 +106,5 @@ Boolean ca_settable(AudioObjectID id, ca_scope scope, ca_sel selector,
+ 
+     return AudioObjectIsPropertySettable(id, &p_addr, data);
+ }
++
++#endif // !TARGET_OS_IPHONE
+diff --git a/audio/out/ao_coreaudio_utils.c b/audio/out/ao_coreaudio_utils.c
+index 8ff76a8..b77ea1e 100644
+--- a/audio/out/ao_coreaudio_utils.c
++++ b/audio/out/ao_coreaudio_utils.c
+@@ -28,14 +28,14 @@
+ #include "audio/format.h"
+ #include "osdep/mac/compat.h"
+ 
+-#if HAVE_COREAUDIO || HAVE_AVFOUNDATION
++#if (HAVE_COREAUDIO || HAVE_AVFOUNDATION) && !TARGET_OS_IPHONE
+ #include "audio/out/ao_coreaudio_properties.h"
+ #include <CoreAudio/HostTime.h>
+ #else
+ #include <mach/mach_time.h>
+ #endif
+ 
+-#if HAVE_COREAUDIO || HAVE_AVFOUNDATION
++#if (HAVE_COREAUDIO || HAVE_AVFOUNDATION) && !TARGET_OS_IPHONE
+ static bool ca_is_output_device(struct ao *ao, AudioDeviceID dev)
+ {
+     size_t n_buffers;
+@@ -300,7 +300,7 @@ int64_t ca_frames_to_ns(struct ao *ao, uint32_t frames)
+ 
+ int64_t ca_get_latency(const AudioTimeStamp *ts)
+ {
+-#if HAVE_COREAUDIO || HAVE_AVFOUNDATION
++#if (HAVE_COREAUDIO || HAVE_AVFOUNDATION) && !TARGET_OS_IPHONE
+     uint64_t out = AudioConvertHostTimeToNanos(ts->mHostTime);
+     uint64_t now = AudioConvertHostTimeToNanos(AudioGetCurrentHostTime());
+ 
+@@ -323,7 +323,7 @@ int64_t ca_get_latency(const AudioTimeStamp *ts)
+ #endif
+ }
+ 
+-#if HAVE_COREAUDIO || HAVE_AVFOUNDATION
++#if (HAVE_COREAUDIO || HAVE_AVFOUNDATION) && !TARGET_OS_IPHONE
+ bool ca_stream_supports_compressed(struct ao *ao, AudioStreamID stream)
+ {
+     AudioStreamRangedDescription *formats = NULL;
+diff --git a/audio/out/ao_coreaudio_utils.h b/audio/out/ao_coreaudio_utils.h
+index 85f674b..7776ab8 100644
+--- a/audio/out/ao_coreaudio_utils.h
++++ b/audio/out/ao_coreaudio_utils.h
+@@ -19,6 +19,7 @@
+ #ifndef MPV_COREAUDIO_UTILS_H
+ #define MPV_COREAUDIO_UTILS_H
+ 
++#include <TargetConditionals.h>
+ #include <AudioToolbox/AudioToolbox.h>
+ #include <inttypes.h>
+ #include <stdbool.h>
+@@ -53,7 +54,7 @@ bool check_ca_st(struct ao *ao, int level, OSStatus code, const char *message);
+     } while (0)
+ 
+ void ca_get_device_list(struct ao *ao, struct ao_device_list *list);
+-#if HAVE_COREAUDIO || HAVE_AVFOUNDATION
++#if (HAVE_COREAUDIO || HAVE_AVFOUNDATION) && !TARGET_OS_IPHONE
+ OSStatus ca_select_device(struct ao *ao, char* name, AudioDeviceID *device);
+ #endif
+ 
+@@ -71,7 +72,7 @@ bool ca_asbd_is_better(AudioStreamBasicDescription *req,
+ int64_t ca_frames_to_ns(struct ao *ao, uint32_t frames);
+ int64_t ca_get_latency(const AudioTimeStamp *ts);
+ 
+-#if HAVE_COREAUDIO || HAVE_AVFOUNDATION
++#if (HAVE_COREAUDIO || HAVE_AVFOUNDATION) && !TARGET_OS_IPHONE
+ bool ca_stream_supports_compressed(struct ao *ao, AudioStreamID stream);
+ OSStatus ca_lock_device(AudioDeviceID device, pid_t *pid);
+ OSStatus ca_unlock_device(AudioDeviceID device, pid_t *pid);


### PR DESCRIPTION
Hi, and thanks for MPVKit — it's really helpful.

## The problem

I hit a case on an Apple TV 4K (3rd gen) running tvOS 26 where there was **no audio at all**. With the default `audiounit` output, some HDMI routes report 32 output channels, and mpv's `audiounit` AO can't open them — it logs `unable to retrieve audio unit channel layout` and playback stays silent. Other apps (that use AVPlayer) play fine on the same TV.

## The idea

mpv already has an `avfoundation` AO that uses `AVSampleBufferAudioRenderer`, and it handles these routes well. The problem is it was only built for macOS. So this PR turns it on for iOS and tvOS too.

## What I changed

1. **Build:** enable `avfoundation` (and keep `coreaudio` off, since it's macOS-only) in the iOS/tvOS branch of `main.swift`.
2. **A small mpv source patch** (`0003-enable-avfoundation-ao-tvos.patch`) so the avfoundation AO and the shared CoreAudio helpers compile on iOS/tvOS. The CoreAudio device HAL (`AudioObject*` / `AudioDeviceID`, device selection and enumeration) only exists on macOS. iOS/tvOS have a single fixed output and no device picking, so I guard that code with `#if !TARGET_OS_IPHONE`. The portable parts (channel layout, ASBD helpers) stay shared.

## Is it safe?

- **macOS is not affected.** The guards are `!TARGET_OS_IPHONE`, so on macOS the code is exactly the same as before.
- **On iOS it is additive.** mpv lists `audiounit` before `avfoundation`, so the default AO does not change. `avfoundation` is only used if you ask for it (`--ao=avfoundation`) or as a fallback.
- Build stays non-GPL.

## Testing

I tested on tvOS 26 (Apple TV 4K 2nd and 3rd gen). With `--ao=avfoundation,audiounit`, audio works on the route that used to be silent, including 5.1.

Happy to change anything — for example moving the per-platform source exclusion into meson, or the style of the guards. Thanks!
